### PR TITLE
adding relaxed and sequential phylip formats

### DIFF
--- a/phylopandas/core.py
+++ b/phylopandas/core.py
@@ -27,6 +27,8 @@ class PhyloPandasSeriesMethods(object):
     to_swiss = seqio.write._write_method('swiss')
     to_fastq = seqio.write._write_method('fastq')
     to_fasta_twoline = seqio.write._write_method('fasta-2line')
+    to_phylip_sequential = seqio.write._write_method('phylip-sequential')
+    to_phylip_relaxed = seqio.write._write_method('phylip-relaxed')
 
 
 @register_dataframe_accessor('phylo')
@@ -52,6 +54,8 @@ class PhyloPandasDataFrameMethods(object):
     read_swiss = seqio.read._read_method('swiss')
     read_fastq = seqio.read._read_method('fastq')
     read_fasta_twoline = seqio.read._read_method('fasta-2line')
+    read_phylip_sequential = seqio.read._read_method('phylip-sequential')
+    read_phylip_relaxed = seqio.read._read_method('phylip-relaxed')
 
     # Tree file reading methods.
     read_newick = treeio.read._read_method('newick')
@@ -68,7 +72,8 @@ class PhyloPandasDataFrameMethods(object):
     to_swiss = seqio.write._write_method('swiss')
     to_fastq = seqio.write._write_method('fastq')
     to_fasta_twoline = seqio.write._write_method('fasta-2line')
-
+    to_phylip_sequential = seqio.write._write_method('phylip-sequential')
+    to_phylip_relaxed = seqio.write._write_method('phylip-relaxed')
 
     # Tree file reading methods.
     to_newick = treeio.write._write_method('newick')

--- a/phylopandas/seqio/__init__.py
+++ b/phylopandas/seqio/__init__.py
@@ -5,6 +5,8 @@ from .read import (read_embl,
                    read_swiss,
                    read_phylip,
                    read_clustal,
-                   read_blast_xml)
+                   read_blast_xml,
+                   read_phylip_relaxed,
+                   read_phylip_sequential)
 
 from . import write

--- a/phylopandas/seqio/read.py
+++ b/phylopandas/seqio/read.py
@@ -147,6 +147,8 @@ read_embl = _read_function('embl')
 read_nexus = _read_function('nexus')
 read_swiss = _read_function('swiss')
 read_fastq = _read_function('fastq')
+read_phylip_sequential = _read_function('phylip-sequential')
+read_phylip_relaxed = _read_function('phylip-relaxed')
 
 
 def read_blast_xml(filename, **kwargs):

--- a/phylopandas/tests/test_frame.py
+++ b/phylopandas/tests/test_frame.py
@@ -43,6 +43,32 @@ def test_read_phylip(path_to_dat):
     assert 'description' in keys
 
 
+def test_read_phylip_relaxed(path_to_dat):
+    # Get path
+    path = os.path.join(path_to_dat, 'PF08793_seed.phylip')
+    df = ph.read_phylip_relaxed(path)
+
+    # Tests
+    keys = df.keys()
+    assert type(df) == ph.DataFrame
+    assert 'id' in keys
+    assert 'sequence' in keys
+    assert 'description' in keys
+
+
+def test_read_phylip_sequential(path_to_dat):
+    # Get path
+    path = os.path.join(path_to_dat, 'PF08793_seed.phylip')
+    df = ph.read_phylip_sequential(path)
+
+    # Tests
+    keys = df.keys()
+    assert type(df) == ph.DataFrame
+    assert 'id' in keys
+    assert 'sequence' in keys
+    assert 'description' in keys
+
+
 class Testframe(object):
 
     @pytest.mark.usefixtures("clean_dat")


### PR DESCRIPTION
Adding two new reading/writing format methods:

1. `read_phylip_relaxed` 
2. `read_phylip_sequential`

This addresses #25.

@ClaudiaPaetzold, if you have a chance at some point, I'd love to hear if this works for your data. 