### PR TITLE
fixed bug for reading blast xml files

### DIFF
--- a/phylopandas/seqio/read.py
+++ b/phylopandas/seqio/read.py
@@ -168,13 +168,13 @@ def read_blast_xml(filename, **kwargs):
 
     # Get alignments from blast result.
     for i, s in enumerate(blast_record.alignments):
-        data['accession'] = s.accession
-        data['hit_def'] = s.hit_def
-        data['hit_id'] = s.hit_id
-        data['title'] = s.title
-        data['length'] = s.length
-        data['e_value'] = s.hsps[0].expect
-        data['sequence'] = s.hsps[0].sbjct
+        data['accession'].append(s.accession)
+        data['hit_def'].append(s.hit_def)
+        data['hit_id'].append(s.hit_id)
+        data['title'].append(s.title)
+        data['length'].append(s.length)
+        data['e_value'].append(s.hsps[0].expect)
+        data['sequence'].append(s.hsps[0].sbjct)
 
     # Port to DataFrame.
     return pd.DataFrame(data)


### PR DESCRIPTION
Fixed bug in `seqio.read.read_blast_xml`.  Rather than appending hits to data dictionary used to construct the data frame, phylopandas assigned each hit as a value to the dictionary.  This caused pandas to throw an error because rather than being handed a dict like:

```
data["accession"] = [1,2,3]
```
it was handed a dict like:
```
data["accession"] = 1
```
Replaced `=` assignments with `.append` calls.