### PR TITLE
read more information from blast xml file

### DIFF
--- a/phylopandas/seqio/read.py
+++ b/phylopandas/seqio/read.py
@@ -168,7 +168,8 @@ def read_blast_xml(filename, **kwargs):
             'subject_start': [],
             'subject_end':[],
             'query_start':[],
-            'query_end':[]}
+            'query_end':[],
+            'uid':[]}
 
     # Get alignments from blast result.
     for i, s in enumerate(blast_record.alignments):
@@ -183,6 +184,7 @@ def read_blast_xml(filename, **kwargs):
         data['subject_end'].append(s.hsps[0].sbjct_end)
         data['query_start'].append(s.hsps[0].query_start)
         data['query_end'].append(s.hsps[0].query_end)
+        data['uid'].append(get_random_id(10))
 
     # Port to DataFrame.
     return pd.DataFrame(data)


### PR DESCRIPTION
tweaked blast reader so phylopandas pulls out the alignment residue positions for the blast result. (subject start, subject end, query start, query end).  Might be worth thinking about pulling even more information out of the xml file.  Maybe we could let a user specify a "verbose" or "minimal" set  of information for the final data frame.  