### PR TITLE
Add tree pruning method

### DIFF
--- a/phylopandas/core.py
+++ b/phylopandas/core.py
@@ -36,7 +36,7 @@ class PhyloPandasSeriesMethods(object):
 
 
 @register_dataframe_accessor('phylo')
-class PhyloPandasDataFrameMethods(object):
+class PhyloPandasDataFrameMethods(treeio.mixin.DataFrameTreeMethods):
     """PhyloPandas accessor to the Pandas DataFrame.
 
     This accessor adds reading/writing methods to the pandas DataFrame that

--- a/phylopandas/treeio/__init__.py
+++ b/phylopandas/treeio/__init__.py
@@ -4,3 +4,4 @@ from .read import (read_nexml,
                    read_dendropy)
 
 from . import write
+from . import mixin

--- a/phylopandas/treeio/mixin.py
+++ b/phylopandas/treeio/mixin.py
@@ -1,0 +1,46 @@
+
+
+class DataFrameTreeMethods:
+    """Tree operations.
+    """
+
+    def prune(self, **cell):
+        """Prune a node or leaf from the current tree.
+        
+        Example call: 
+            
+            df.phylo.prune(id='1')
+        
+        Parameters
+        ----------
+        cell: 
+            a column label and value pair. 
+            
+        Returns
+        -------
+        df : 
+            DataFrame with the items in the subtree 
+            below the given node pruned out.
+        """
+        if cell == {}:
+            raise Exception("Only one option allowed.")
+        if len(cell) > 1:
+            raise Exception("Only one item allowed")
+        
+        df = self._data
+
+        col = list(cell.keys())[0]
+        val = list(cell.values())[0]
+        
+        # Convert to tree
+        tree = df.phylo.to_dendropy(node_col=col)
+        
+        # Find node with the given label
+        node = tree.find_node_with_label(val)
+        
+        # Get all descendant nodes
+        descendants = list(node.postorder_iter())
+        
+        # Remove them from dataframe
+        nodes_to_rm = [d.label for d in descendants]
+        return df.loc[~df[col].isin(nodes_to_rm)]


### PR DESCRIPTION
Adds a `.phylo.prune()` method.

The function takes a simple kwarg. The key is the column name in the DataFrame and the value is row's value at that column. 



## Example:

In the example below, prune a node "3" by passing in `id='3'`. `id` is the column name. `'3'` is the value.

Before:
```python
df.phylo.display()
```
![Screen Shot 2019-10-03 at 1 54 10 PM](https://user-images.githubusercontent.com/2791223/66163565-7c77ac80-e5e5-11e9-823a-7ced1327edda.png)



After:
```python
df.phylo.prune(id='3')
df.phylo.display
```
![Screen Shot 2019-10-03 at 1 54 18 PM](https://user-images.githubusercontent.com/2791223/66163575-83062400-e5e5-11e9-866b-0cef43f49700.png)
